### PR TITLE
Documentation

### DIFF
--- a/docs/Examples/examples_commandline/descriptor_generation.rst
+++ b/docs/Examples/examples_commandline/descriptor_generation.rst
@@ -43,6 +43,6 @@ QDESCP module.
 
 .. code:: shell
 
-   python -m aqme --qdescp --files "CSEARCH/*.sdf" --boltz
+   python -m aqme --qdescp --program xtb --files "CSEARCH/*.sdf"
 
 

--- a/docs/Examples/examples_commandline/end_to_end/example_1.rst
+++ b/docs/Examples/examples_commandline/end_to_end/example_1.rst
@@ -99,7 +99,7 @@ Step 6: Creating Gaussian input files for NMR calcs with QPREP
 
 .. code:: shell
 
-   python -m aqme --w_dir_main "Strychnine_com_files/success" --program gaussian --mem 24GB --nprocs 12 --suffix SP --destination Strychnine_sp_files --files "Strychnine_com_files/success/*.log" --qm_input "B3LYP/6-311+G(2d,p) scrf=(solvent=chloroform,smd) nmr=giao" 
+   python -m aqme --qprep --w_dir_main "Strychnine_com_files/success" --program gaussian --mem 24GB --nprocs 12 --suffix SP --destination Strychnine_sp_files --files "Strychnine_com_files/success/*.log" --qm_input "B3LYP/6-311+G(2d,p) scrf=(solvent=chloroform,smd) nmr=giao" 
 
 
 Step 7: Running Gaussian NMR calcs

--- a/docs/Examples/examples_commandline/end_to_end/example_1.rst
+++ b/docs/Examples/examples_commandline/end_to_end/example_1.rst
@@ -85,7 +85,14 @@ Step 5: Resubmission of unsuccessful calculations (if any) with suggestions from
 -------------------------------------------------------------------------------------
 
 Now we need to run the generated COM files (in fixed_QM_inputs) with Gaussian 
-like we did in Step 3
+like we did in Step 3.
+
+After the calculations finish we check again the files using QCORR
+
+.. code:: shell
+
+   python -m aqme --qcorr --files "Strychnine_com_files/failed/run_1/fixed_QM_inputs/*.log" --isom_type com --isom_inputs "Strychnine_com_files/failed/run_1/fixed_QM_inputs" --nprocs 12 --mem 24GB
+
 
 Step 6: Creating Gaussian input files for NMR calcs with QPREP
 --------------------------------------------------------------

--- a/docs/Examples/examples_commandline/end_to_end/example_1.rst
+++ b/docs/Examples/examples_commandline/end_to_end/example_1.rst
@@ -108,6 +108,14 @@ Step 7: Running Gaussian NMR calcs
 Now we need to run the generated COM files (in sp_path) with Gaussian 
 like we did in Step 3
 
+After the calculations end, we create JSON files with QCORR to store the 
+information from the resulting LOG files
+
+.. code:: shell
+
+   python -m aqme --qcorr --files "Strychnine_sp_files/*.log"
+
+
 Step 8: Obtaining Boltzmann weighted NMR shifts with QDESCP
 -----------------------------------------------------------
 

--- a/docs/Examples/examples_commandline/end_to_end/example_1.rst
+++ b/docs/Examples/examples_commandline/end_to_end/example_1.rst
@@ -78,7 +78,7 @@ Step 4: QCORR analysis including isomerization filter
 
 .. code:: shell 
 
-   python --qcorr --files "Strychnine_com_files/*.log" --freq_conv "opt=(calcfc,maxstep=5)" --isom_type com --isom_inputs Strychnine_com_files --nprocs 24 --mem 96GB
+   python -m aqme --qcorr --files "Strychnine_com_files/*.log" --freq_conv "opt=(calcfc,maxstep=5)" --isom_type com --isom_inputs Strychnine_com_files --nprocs 12 --mem 24GB
 
 
 Step 5: Resubmission of unsuccessful calculations (if any) with suggestions from AQME

--- a/docs/Examples/examples_commandline/end_to_end/example_1.rst
+++ b/docs/Examples/examples_commandline/end_to_end/example_1.rst
@@ -113,8 +113,7 @@ Step 8: Obtaining Boltzmann weighted NMR shifts with QDESCP
 
 .. code:: shell 
 
-   python -m aqme --qdescp --program nmr --boltz --destination Strychnine_nmr_files --nmr_slope "[-1.0537, -1.0784]" --nmr_intercept "[181.7815,31.8723]" --nmr_experim Experimental_NMR_shifts.csv --files "Strychnine_com_files/Strychnine_sp_files/success/SP_calcs/json_files/*.json"
-
+   python -m aqme --qdescp --program nmr --destination Strychnine_nmr_files --nmr_slope "[-1.0537, -1.0784]" --nmr_intercept "[181.7815,31.8723]" --nmr_experim Experimental_NMR_shifts.csv --files "Strychnine_sp_files/success/SP_calcs/json_files/*.json"
 
 Step 9: Calculating conformer populations with GoodVibes
 --------------------------------------------------------

--- a/docs/Examples/examples_commandline/end_to_end/example_1.rst
+++ b/docs/Examples/examples_commandline/end_to_end/example_1.rst
@@ -130,8 +130,9 @@ Step 9: Calculating conformer populations with GoodVibes
 
    mkdir -p Strychine_GoodVibes-analysis
    cp Strychnine_com_files/success/*.log Strychine_GoodVibes-analysis/
+   cp Strychnine_sp_files/success/SP_calcs/*.log Strychine_GoodVibes-analysis/
    cd Strychine_GoodVibes-analysis
-   python -m goodvibes --xyz -c 1 *.log --boltz 
+   python -m goodvibes --xyz -c 1 *.log --boltz --spc SP
    cd ..
 
 

--- a/docs/Examples/examples_commandline/end_to_end/example_2.rst
+++ b/docs/Examples/examples_commandline/end_to_end/example_2.rst
@@ -143,6 +143,7 @@ Now we create the input files of the minima (intermediates, reagents and product
 .. code:: shell 
 
    python -m aqme --qprep --program gaussian --mem 72GB --nprocs 16 --files "CSEARCH/D*.sdf" --qm_input "B3LYP/def2tzvp opt freq"
+   python -m aqme --qprep --program gaussian --mem 72GB --nprocs 16 --files "CSEARCH/P*.sdf" --qm_input "B3LYP/def2tzvp opt freq"
 
 
 Step 4: Running Gaussian inputs for optimization and frequency calcs externally

--- a/docs/Examples/examples_commandline/end_to_end/example_2.rst
+++ b/docs/Examples/examples_commandline/end_to_end/example_2.rst
@@ -136,14 +136,14 @@ We first create the input files of the transition states
 
 .. code:: shell 
 
-   python -m aqme --qprep --program gaussian --mem 72GB --nprocs 16 --files "CSEARCH/TS*crest.sdf" --qm_input "B3LYP/def2tzvp opt=(ts,calcfc,noeigen) freq"
+   python -m aqme --qprep --program gaussian --mem 32GB --nprocs 16 --files "CSEARCH/TS*crest.sdf" --qm_input "B3LYP/def2tzvp opt=(ts,calcfc,noeigen) freq"
 
 Now we create the input files of the minima (intermediates, reagents and products) 
 
 .. code:: shell 
 
-   python -m aqme --qprep --program gaussian --mem 72GB --nprocs 16 --files "CSEARCH/D*.sdf" --qm_input "B3LYP/def2tzvp opt freq"
-   python -m aqme --qprep --program gaussian --mem 72GB --nprocs 16 --files "CSEARCH/P*.sdf" --qm_input "B3LYP/def2tzvp opt freq"
+   python -m aqme --qprep --program gaussian --mem 32GB --nprocs 16 --files "CSEARCH/D*.sdf" --qm_input "B3LYP/def2tzvp opt freq"
+   python -m aqme --qprep --program gaussian --mem 32GB --nprocs 16 --files "CSEARCH/P*.sdf" --qm_input "B3LYP/def2tzvp opt freq"
 
 
 Step 4: Running Gaussian inputs for optimization and frequency calcs externally
@@ -166,7 +166,7 @@ Step 5: QCORR analysis
 
 .. code:: shell
 
-   python -m aqme --qcorr --files "QCALC/*.log" --freq_conv "opt=(calcfc,maxstep=5)" --mem 72GB --nprocs 16
+   python -m aqme --qcorr --files "QCALC/*.log" --freq_conv "opt=(calcfc,maxstep=5)" --mem 32GB --nprocs 16
 
 
 Step 6: Resubmission of unsuccessful calculations (if any) with suggestions from AQME

--- a/docs/Examples/examples_commandline/end_to_end/example_2.rst
+++ b/docs/Examples/examples_commandline/end_to_end/example_2.rst
@@ -136,14 +136,14 @@ We first create the input files of the transition states
 
 .. code:: shell 
 
-   python -m aqme --qprep --program gaussian --mem 32GB --nprocs 16 --files "CSEARCH/TS*crest.sdf" --qm_input "B3LYP/def2tzvp opt=(ts,calcfc,noeigen) freq"
+   python -m aqme --qprep --program gaussian --mem 32GB --nprocs 16 --files "CSEARCH/TS*crest.sdf" --qm_input "B3LYP/def2tzvp opt=(ts,calcfc,noeigen,maxstep=5) freq=noraman"
 
 Now we create the input files of the minima (intermediates, reagents and products) 
 
 .. code:: shell 
 
-   python -m aqme --qprep --program gaussian --mem 32GB --nprocs 16 --files "CSEARCH/D*.sdf" --qm_input "B3LYP/def2tzvp opt freq"
-   python -m aqme --qprep --program gaussian --mem 32GB --nprocs 16 --files "CSEARCH/P*.sdf" --qm_input "B3LYP/def2tzvp opt freq"
+   python -m aqme --qprep --program gaussian --mem 32GB --nprocs 16 --files "CSEARCH/D*.sdf" --qm_input "B3LYP/def2tzvp opt freq=noraman"
+   python -m aqme --qprep --program gaussian --mem 32GB --nprocs 16 --files "CSEARCH/P*.sdf" --qm_input "B3LYP/def2tzvp opt freq=noraman"
 
 
 Step 4: Running Gaussian inputs for optimization and frequency calcs externally

--- a/docs/Examples/examples_commandline/end_to_end/example_2.rst
+++ b/docs/Examples/examples_commandline/end_to_end/example_2.rst
@@ -98,8 +98,8 @@ We visualize the third pair of reactants to be able to set up the constraints.
 
 
 According to the image we will add the following constraints to the CSV, in the 
-constraints_dist column we will include :code:`[[3,10,2.35],[0,11,2.35]]` and in 
-the constraints_dihedral column we will include :code:`[[0,3,10,11,0]]`
+constraints_dist column we will include :code:`[[3,5,2.35],[0,6,2.35]]` and in 
+the constraints_dihedral column we will include :code:`[[0,3,5,6,0]]`
 
 
 Step 2: CSEARCH conformational sampling

--- a/docs/Examples/examples_python/descriptor_generation.rst
+++ b/docs/Examples/examples_python/descriptor_generation.rst
@@ -51,5 +51,7 @@ QDESCP module.
 
    conformer_files = [str(filepath) for filepath in Path('CSEARCH').glob('*.sdf')]
    
-   qdescp(files=conformer_files,boltz=True)
+   qdescp(files=conformer_files,
+          program='xtb',
+          boltz=True)
 

--- a/docs/Examples/examples_python/end_to_end/example_1.rst
+++ b/docs/Examples/examples_python/end_to_end/example_1.rst
@@ -176,14 +176,18 @@ Step 8: Running Gaussian NMR calcs
 Now we need to run the generated COM files (in sp_path) with Gaussian 
 like we did in Step 4
 
+After the calculations end, we create JSON files with QCORR to store the 
+information from the resulting LOG files
+
+.. code:: python
+
+   log_files=f'{sp_path}/*.log'
+   qcorr(files=log_files)
+
 Step 9: Obtaining Boltzmann weighted NMR shifts with QDESCP
 -----------------------------------------------------------
 
 .. code:: python
-
-    # Create JSON files with QCORR to store the information from the resulting LOG files
-    log_files=f'{sp_path}/*.log'
-    qcorr(files=log_files)
     
     # Analyze the JSON files to calculate the Boltzmann averaged shielding tensors
 

--- a/docs/Examples/examples_python/end_to_end/example_1.rst
+++ b/docs/Examples/examples_python/end_to_end/example_1.rst
@@ -211,8 +211,10 @@ Step 10: Calculating conformer populations with GoodVibes
 
 .. code:: python
 
-    log_files = glob.glob(f'{success_folder}/*.log')
-    
+    opt_files = glob.glob(f'{success_folder}/*.log')
+    sp_files = glob.glob(f'{sp_path}/success/SP_calcs/*.log')
+    log_files = opt_files + sp_files
+
     w_dir_main  = Path(os.getcwd())
     GV_folder = w_dir_main.joinpath('Strychine_GoodVibes-analysis')
     GV_folder.mkdir(exist_ok=True, parents=True)

--- a/docs/Examples/examples_python/end_to_end/example_1.rst
+++ b/docs/Examples/examples_python/end_to_end/example_1.rst
@@ -120,14 +120,27 @@ Step 5: QCORR analysis including isomerization filter
           freq_conv='opt=(calcfc,maxstep=5)',
           isom_type='com',
           isom_inputs=com_path,
-          nprocs=24,
-          mem='96GB')
+          nprocs=12,
+          mem='24GB')
 
 Step 6: Resubmission of unsuccessful calculations (if any) with suggestions from AQME
 -------------------------------------------------------------------------------------
 
 Now we need to run the generated COM files (in fixed_QM_inputs) with Gaussian 
 like we did in Step 4
+
+After the calculations finish we check again the files using QCORR
+
+.. code:: python
+
+   new_log_files = f'{com_path}/failed/run_1/fixed_QM_inputs/*.log'
+
+   qcorr(files=new_log_files,
+          isom_type='com',
+          isom_inputs=com_path/'failed/run_1/fixed_QM_inputs',
+          nprocs=12,
+          mem='24GB')
+
 
 Step 7: Creating Gaussian input files for NMR calcs with QPREP
 --------------------------------------------------------------

--- a/docs/Examples/examples_python/end_to_end/example_2.rst
+++ b/docs/Examples/examples_python/end_to_end/example_2.rst
@@ -191,7 +191,7 @@ Step 4: Creating Gaussian input files for optimization and frequency with QPREP
     sdf_TS_files = glob.glob('CSEARCH/TS*crest.sdf')
 
     # COM files for the TSs
-    qm_input_TS = 'B3LYP/def2tzvp opt=(ts,calcfc,noeigen) freq'
+    qm_input_TS = 'B3LYP/def2tzvp opt=(ts,calcfc,noeigen,maxstep=5) freq=noraman'
     qprep(files=sdf_TS_files,
           program=program,
           qm_input=qm_input_TS,
@@ -201,7 +201,7 @@ Step 4: Creating Gaussian input files for optimization and frequency with QPREP
     sdf_INT_files = glob.glob('CSEARCH/D*.sdf') + glob.glob('CSEARCH/P*.sdf')
     
     # COM files for intermediates, reagents and products
-    qm_input_INT = 'B3LYP/def2tzvp opt freq'
+    qm_input_INT = 'B3LYP/def2tzvp opt freq=noraman'
     
     qprep(files=sdf_INT_files,
           program=program,

--- a/docs/Examples/examples_python/end_to_end/example_2.rst
+++ b/docs/Examples/examples_python/end_to_end/example_2.rst
@@ -185,7 +185,7 @@ Step 4: Creating Gaussian input files for optimization and frequency with QPREP
 .. code:: python
 
     program = 'gaussian'
-    mem='72GB'
+    mem='32GB'
     nprocs=16
     
     sdf_TS_files = glob.glob('CSEARCH/TS*crest.sdf')

--- a/docs/Examples/examples_python/end_to_end/example_2.rst
+++ b/docs/Examples/examples_python/end_to_end/example_2.rst
@@ -142,8 +142,8 @@ We visualize the third pair of reactants to be able to set up the constraints.
 .. centered:: |pair_3_map|
 
 According to the image we will add the following constraints to the CSV, in the 
-constraints_dist column we will include :code:`[[3,10,2.35],[0,11,2.35]]` and in 
-the constraints_dihedral column we will include :code:`[[0,3,10,11,0]]`
+constraints_dist column we will include :code:`[[3,5,2.35],[0,6,2.35]]` and in 
+the constraints_dihedral column we will include :code:`[[0,3,5,6,0]]`
 
 
 Step 3: CSEARCH conformational sampling


### PR DESCRIPTION
- Included the copy of the SP.log files at the last step of the Strychnine examples
- Added to the step where the NMR calculations are run, the use of qcorr to generate the json files in the strychnine example
- Fixed filepaths in Step 8 of the commandline Strychnine example
- added missing --qprep to Step 6 of the commandline Strychnine example
- Added a new qcorr step in the Strychnine example within the resubmission step
- Fixed the commandline of Step 4 in End to end Strychine commandline example
- Fixed the numbers of the constraints in the Diels alder end to end examples
- Updated the gaussian command lines of the Diels alder end to end examples
- changed the 72GB of memory for 32GB instead in the end to end examples of the Diels-Alder
- Included the generation of the QM input for the TS end to end command line example
- Added the program keyword to the qdescp examples