### PR TITLE
fixed --qm_end when using 'modifysph'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           # pip-dependency-file: test-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
       - run: |
           # install RDKit and OpenBabel
-          conda install -y -c conda-forge rdkit
+          pip install rdkit-pypi
           conda install -y -c conda-forge openbabel
           # install xTB, xTB-python and CREST
           conda install -y -c conda-forge xtb


### PR DESCRIPTION
Huber, Truhlar,and Cramer recommend using different radius for bromine and iodine in the SMD18 (https://doi.org/10.1002/chem.201803652). The lines must be added after the gen/genecp info in g16, unlike freezing bonds etc. The proposed change will take care of that by looking for 'modifysph' in the --qm_end input. I tested it on mac with:
--qm_end "B 1 2 F"$'\n''B 1 5 F'$'\n''B 2 5 F' --> before genecp
--qm_end "modifysph"$'\n'$'\n'"I 2.74" --> after genecp
--qm_end "$nbo bndidx $end" --> before genecp

- changed config.yml file