### PR TITLE
Temporal bug fix for calculations that fail before the first step 

### DIFF
--- a/aqme/qcorr.py
+++ b/aqme/qcorr.py
@@ -573,15 +573,19 @@ class qcorr:
                         cclib_data["metadata"]["keywords line"] = 'SlowConv ' + cclib_data["metadata"]["keywords line"]
 
             if errortype in ["not_specified", "SCFerror"]:
-                if "geometric values" in cclib_data["optimization"]:
-                    RMS_forces = [
-                        row[1] for row in cclib_data["optimization"]["geometric values"]
-                    ]
-                    # cclib uses None when the values are corrupted in the output files, replace None for a large number
-                    RMS_forces = [10000 if val is None else val for val in RMS_forces]
-                    min_RMS = RMS_forces.index(min(RMS_forces))
+                if "optimization" in cclib_data:
+                    if "geometric values" in cclib_data["optimization"]:
+                        RMS_forces = [
+                            row[1] for row in cclib_data["optimization"]["geometric values"]
+                        ]
+                        # cclib uses None when the values are corrupted in the output files, replace None for a large number
+                        RMS_forces = [10000 if val is None else val for val in RMS_forces]
+                        min_RMS = RMS_forces.index(min(RMS_forces))
+                    else:
+                        # for optimizations that fail in the first step
+                        min_RMS = 0
                 else:
-                    # for optimizations that fail in the first step
+                    # for optimizations that fail before the first step
                     min_RMS = 0
 
                 atom_types, cartesians = QM_coords(


### PR DESCRIPTION
AQME was failing to evaluate a calculation that failed before finishing the first optimisation step due to an error in the SCRF input (read was specified but no details were added at the end). 

Details and testing files have been sent by email so they can be checked before merging.
