### PR TITLE
fix "folder_count" referenced before assignment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
           # install and run pytest
           pip install pytest
           pip install pytest-cov
+          pip install pytest-mock
           # the format of the codecov report has to be scpecified or it doesn't create for some reason
           python -m pytest -v --cov=aqme --cov-report=xml
           rm -r /tmp/*

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,80 @@
+import pytest
+from aqme.utils import check_run
+
+
+class FakePath:
+    def __init__(self, name) -> None:
+        self.name = name
+
+    def __truediv__(self, p):
+        return self
+
+    def as_posix(self):
+        return self.name
+
+    def joinpath(self, p):
+        return self.name + p
+
+
+@pytest.mark.parametrize(
+    "w_dir, path_exists, expected_folder_count, expected_resume_qcorr",
+    [
+        pytest.param(
+            FakePath("/an/ordinary/working/directory"),
+            True,
+            1,
+            False,
+            id="no failed directory",
+        ),
+        pytest.param(
+            FakePath("/a/working/directory/with/dir/named/failed_jobs/directory"),
+            True,
+            1,
+            False,
+            id='Shall not trigger exception: "folder_count referenced before assignment"',
+        ),
+        pytest.param(
+            FakePath("/a/working/directory/with/failed/run_1/directory"),
+            True,
+            2,
+            True,
+            id="failed directory",
+        ),
+        pytest.param(
+            FakePath("/a/working/directory/with/failed/run_1/directory"),
+            False,
+            2,
+            True,
+            id="failed run 1",
+        ),
+        pytest.param(
+            FakePath("/a/working/directory/with/failed/run_13/directory"),
+            True,
+            14,
+            True,
+            id="failed run 13",
+        ),
+        pytest.param(
+            FakePath(
+                "/a/working/directory/with/my_testrun_12/directory/failed_results/run_1/"
+            ),
+            True,
+            1,
+            False,
+            id="match the last run_xx",
+        ),
+    ],
+)
+def test_check_run(
+    mocker, w_dir, path_exists, expected_folder_count, expected_resume_qcorr
+):
+    mocker.patch("pathlib.Path.as_posix", return_value=w_dir)
+    mocker.patch("os.listdir", return_value=w_dir.name.split("/"))
+    mocker.patch("os.path.exists", return_value=path_exists)
+
+    try:
+        assert (expected_folder_count, expected_resume_qcorr) == check_run(
+            w_dir=w_dir
+        )
+    except UnboundLocalError as e:
+        pytest.fail(f":: {e}")


### PR DESCRIPTION
This exception is raised in aqme.utils.check_run function when "w_dir" path has "failed" in at least one of its directories.

How to reproduce:
- Create a directory containing "failed" : /home/my_name/testing_molecule_xyz/failed_results
- Move into it
- Run for e.g. an optimization+correction that are know to succeed
- `check_run()` will detect "failed" and not "run_"; therefore will enter the first if branch that leads to the exception.