### PR TITLE
Fixed minor typos in the docstrings

### DIFF
--- a/aqme/csearch/base.py
+++ b/aqme/csearch/base.py
@@ -91,7 +91,8 @@ General RDKit-based
       might be atoms, bonds, angles and dihedral. For example, a rule to keep only
       molecules with C-Pd-C atoms at 180 degrees: ['[C][Pd][C]',180].
       Special rules (--geom ['RULE_NAME']):
-        1. ['Ir_squareplanar']
+
+         1. ['Ir_squareplanar']
    bond_thres : float, default=0.2
       Threshold used to discard bonds in the geom option (+-0.2 A) 
    angle_thres : float, default=30
@@ -172,8 +173,8 @@ CREST only
       Additional keywords for CREGEN (i.e. cregen_keywords='--ethr 0.02')
    xtb_keywords : str, default=None
       Define additional keywords to use in the xTB pre-optimization that are not 
-      included in -c, --uhf, -P and --input. For example: '--alpb ch2cl2 --gfn 1' 
-    crest_nrun : int, default=1
+      included in -c, --uhf, -P and --input. For example: '--alpb ch2cl2 --gfn 1'
+   crest_nrun : int, default=1
       Specify as number of runs if multiple starting points from RDKit starting points is required.
 """
 #####################################################.

--- a/aqme/qcorr.py
+++ b/aqme/qcorr.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Parameters
 ----------
 
@@ -35,7 +35,7 @@ Parameters
    dup_threshold : float, default=0.0001
       Energy (in hartree) used as the energy difference in E, H and G to detect 
       duplicates
-    ro_threshold : float, default=0.1
+   ro_threshold : float, default=0.1
       Rotational constant value used as the threshold to detect duplicates 
    isom_type : str, default=None
       Check for isomerization from the initial input file to the resulting 

--- a/aqme/qcorr_utils.py
+++ b/aqme/qcorr_utils.py
@@ -171,6 +171,7 @@ def full_check(w_dir_main=os.getcwd(), destination_fullcheck="", files="*.json",
     """
     Checks that multiple calculations were done following the same protocols, including
     program and version, grid size, level of theory, dispersion and solvation model.
+    
     Parameters
     ----------
     w_dir_main : str

--- a/aqme/qdescp.py
+++ b/aqme/qdescp.py
@@ -47,7 +47,7 @@ xTB descriptors
       Performs an initial xTB geometry optimization before calculating descriptors
 
 DBSTEP descriptors
-++++++++++++++
+++++++++++++++++++
 
    dbstep_calc : bool, default=False
       Whether to add a DBSTEP calculation of buried volume when generating atomic descriptors 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,6 +1,6 @@
 .. aqme-banner-start
 
-.. |aqme_banner| image:: ./Logos/AQME_logo.jpg
+.. |aqme_banner| image:: ../Logos/AQME_logo.jpg
 
 |aqme_banner|
 
@@ -140,6 +140,7 @@ Extra requirements if `CMIN` is used with ANI models:
    pip install ase
 
 .. code-block:: shell 
+
    pip install torch torchvision torchani
 
 Extra requirements if `QDESCP` is used with DBSTEP:  


### PR DESCRIPTION
Fixed the typo in the QDESC module documentation that was leading to an empty section in the readthedocs. Also fixed some minor errors in the docstrings and .rst that popped up during the sphinx build process.