### PR TITLE
Fix atomic descp

### DIFF
--- a/aqme/qdescp.py
+++ b/aqme/qdescp.py
@@ -125,7 +125,10 @@ from aqme.qdescp_utils import (
     remove_invalid_smarts,
     update_atom_props_json,
     find_level_names,
-    setup_env
+    setup_env,
+    extract_smiles_from_file,
+    extract_numeric_mapping,
+    validate_atom_mapping_consistency
 )
 
 from aqme.csearch.crest import xyzall_2_xyz
@@ -365,6 +368,18 @@ class qdescp:
         # Delete a SMARTS pattern if it is not compatible with more than 75% of the sdf files
         if len(smarts_targets) > 0:
             smarts_targets = remove_invalid_smarts(self,mol_list,smarts_targets)
+        
+        # Validate atom mapping consistency only if numeric mapping mode is active
+        mapping_numbers = extract_numeric_mapping(smarts_targets)
+        if mapping_numbers:
+            if not validate_atom_mapping_consistency(
+                qdescp_files,
+                mapping_numbers,
+                extract_smiles_from_file,
+                self.args.log
+            ):
+                self.args.log.finalize()
+                sys.exit()
 
         # Get descriptors (denovo, interpret, full)
         descp_dict = collect_descp_lists()
@@ -989,7 +1004,6 @@ class qdescp:
             f"were created in {self.args.initial_dir}"
         )
 
-
     def gather_files_and_run(self, destination, file, atom_props, smarts_targets, bar):
         """Process input file(s) through xTB calculation and property collection.
         
@@ -1020,10 +1034,11 @@ class qdescp:
         
         # Get conformers and their properties
         xyz_files, xyz_charges, xyz_mults = self._get_conformer_data(file, name, ext)
-        
+
         # Process each conformer
         for xyz_file, charge, mult in zip(xyz_files, xyz_charges, xyz_mults):
             name_xtb = '.'.join(os.path.basename(Path(xyz_file)).split(".")[:-1])
+          
             self._process_single_conformer(
                 destination, file, xyz_file, charge, mult, name_xtb, 
                 atom_props, smarts_targets

--- a/aqme/qdescp_utils.py
+++ b/aqme/qdescp_utils.py
@@ -1851,10 +1851,16 @@ def get_mol_assign(self,
         for i, line in enumerate(lines):
             if ">  <SMILES>" in line and i + 1 < len(lines):
                 smiles = lines[i + 1].strip().split()[0]
-                mol = Chem.MolFromSmiles(smiles)
-                if mol is not None:
-                    return Chem.AddHs(mol)
 
+                params = Chem.SmilesParserParams()
+                params.removeHs = False
+
+                mol = Chem.MolFromSmiles(smiles, params)
+                if mol is not None:
+                    Chem.SanitizeMol(mol)
+                    mol = Chem.AddHs(mol)
+                    return mol
+                
         # Fall back to SDF parsing if no SMILES found
         mols = load_sdf(str(sdf_path))
         if not mols:
@@ -2246,7 +2252,7 @@ def get_prefix_atom_props(
             atom_counters[atom_type] = 1
         # If the pattern is a single atom number, we include that number in the match name
         if str(pattern).isdigit():  # This means the pattern is an atom number
-            match_name = f'Atom_{pattern}'
+             match_name = f'Atom_{pattern}_{atom_type}'
         else:
             # If it's a SMARTS pattern or more than one atom
             if pattern in periodic_table():

--- a/aqme/qdescp_utils.py
+++ b/aqme/qdescp_utils.py
@@ -1857,7 +1857,6 @@ def get_mol_assign(self,
 
                 mol = Chem.MolFromSmiles(smiles, params)
                 if mol is not None:
-                    Chem.SanitizeMol(mol)
                     mol = Chem.AddHs(mol)
                     return mol
                 
@@ -2362,3 +2361,123 @@ def update_atom_props_json(
                     prefixes_atom_prop.append(prefix)
 
     return prefixes_atom_prop, json_data
+
+def extract_smiles_from_file(file_path):
+    """
+    Extract SMILES from an SDF file.
+    Returns the SMILES string or None if not found.
+    """
+    with open(file_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+        for i, line in enumerate(lines):
+            if ">  <SMILES>" in line:
+                return lines[i + 1].strip().split()[0]
+    return None
+
+def extract_numeric_mapping(smarts_targets):
+    """
+    Extract numeric mapping identifiers only from smarts_targets.
+    """
+    mapping_numbers = set()
+
+    for target in smarts_targets:
+        cleaned = target.replace("'", "").strip()
+
+        if cleaned.isdigit():
+            mapping_numbers.add(int(cleaned))
+
+    return mapping_numbers
+
+def validate_atom_mapping_consistency(
+    files,
+    mapping_numbers,
+    extract_smiles_fn,
+    logger
+):
+    """
+    Validate that numeric atom mappings (1, 2, 3, ...) are consistent
+    across all input SMILES.
+
+    Returns True if validation passes, False otherwise.
+    """
+
+    # Fail fast: this function should only be called when mapping_numbers exist
+    if not mapping_numbers:
+        raise ValueError(
+            "validate_atom_mapping_consistency() was called with empty "
+            "mapping_numbers. This indicates a workflow logic error."
+        )
+
+    # Collect in set() observed symbols for each mapping number
+    # If inconsistencies arise later, the set will have more than one symbol for that mapping number
+    global_mapping = {num: set() for num in mapping_numbers}
+
+    for file in files:
+        smi = extract_smiles_fn(file)
+        if smi is None:
+            logger.write(
+                f'\nx  WARNING! No SMILES found in "{file}". '
+                "Atom mapping validation could not be performed."
+            )
+            return False
+
+        # Parse SMILES preserving explicit hydrogens
+        params = Chem.SmilesParserParams()
+        params.removeHs = False
+        mol = Chem.MolFromSmiles(smi, params)
+
+        if mol is None:
+            logger.write(
+                f'\nx  WARNING! RDKit failed to parse SMILES in "{file}". '
+                "Atom mapping validation failed."
+            )
+            return False
+        
+        # Extract mapping numbers and their corresponding symbols in this molecule.
+        # We use a set to detect duplicated mapping numbers within the same molecule.
+        local_map = {num: set() for num in mapping_numbers}
+
+        for atom in mol.GetAtoms():
+            map_num = atom.GetAtomMapNum()
+            if map_num in mapping_numbers:
+                local_map[map_num].add(atom.GetSymbol())
+
+        # Ensure requested mappings exist in this molecule
+        for num in mapping_numbers:
+
+            # Mapping requested but not present
+            if len(local_map[num]) == 0:
+                logger.write(
+                    f'\nx  WARNING! Atom mapping {num} was requested but '
+                    f'not found in the SMILES of "{file}".'
+                )
+                return False
+
+            # Mapping appears more than once in the same molecule
+            # (e.g. [C:2](=[O:2])) which is chemically inconsistent
+            if len(local_map[num]) > 1:
+                logger.write(
+                    f'\nx  WARNING! Atom mapping {num} appears multiple times '
+                    f'in "{file}" with different elements {local_map[num]}. '
+                    "Each mapping number must correspond to a single atom."
+                )
+                return False
+
+            # Add the atomic symbol for this mapping number.
+            # A set is used so identical symbols across molecules do not duplicate.
+            # If more than one symbol appears later, inconsistency is detected.
+            symbol = next(iter(local_map[num]))
+            global_mapping[num].add(symbol)
+
+    # Ensure consistency across all molecules
+    for num, symbols in global_mapping.items():
+        if len(symbols) > 1:
+            logger.write(
+                f"\nx  WARNING! Inconsistent atomic symbols detected for "
+                f"mapping {num} across input files {symbols}. "
+                "Mapped atoms must correspond to the same element "
+                "in all molecules."
+            )
+            return False
+
+    return True

--- a/tests/test_qdescp.py
+++ b/tests/test_qdescp.py
@@ -262,8 +262,8 @@ def test_qdescp_xtb(file):
 
     elif file in ['test_idx.csv','test_idx_cmd.csv']:
         pd_boltz_interpret = pd.read_csv(file_descriptors_interpret)
-        assert 'Atom_1_Partial charge' in pd_boltz_interpret
-        assert round(pd_boltz_interpret['Atom_1_Partial charge'][1],1) == -0.1
+        assert 'Atom_1_C_Partial charge' in pd_boltz_interpret
+        assert round(pd_boltz_interpret['Atom_1_C_Partial charge'][1],1) == -0.1
 
     # Checking molecular and atomic descriptors
     def check_descriptors(pd_boltz, descriptors, excluded_descriptors, desc_type, file_test):


### PR DESCRIPTION
1. Atomic descriptor generation fix: Ensures consistent atom ordering by preserving explicit hydrogens during SMILES parsing (removeHs=False), preventing index mismatches in atomic descriptors.

3. Atomic mapping name fix: Updates atom match naming to include the atom symbol for single-atom patterns.